### PR TITLE
Environment Variables

### DIFF
--- a/History.md
+++ b/History.md
@@ -13,6 +13,28 @@
 * Env variables
 
 
+## 1.6.5
+* environment variables can now be registered in norma config files and they will be populated on the process environment. These will be merged in the typical order for Norma (e.g. global < local < settings)
+
+```coffeescript
+
+name: "norma-projects"
+
+tasks:
+  javascript:
+    src: "_source/pre/**/*"
+    dest: "_source/tmp"
+  build:
+    "@extend": "javascript"
+    src: "_source/build.min"
+    dest: ""
+    order: "post"
+
+env:
+  NODE_ENV: "production"
+  VELOCITY: 0
+
+```
 
 ## 1.6.4
 * caching of packages for faster start times on new projects

--- a/lib/libraries.coffee
+++ b/lib/libraries.coffee
@@ -166,6 +166,15 @@ module.exports = (Norma) ->
   Norma.getPackages = require "./utilities/register-packages"
 
 
+  ###
+
+    Env binding
+
+    Merges config based env and populates the process.env
+
+  ###
+  require("./utilities/add-env-vars")()
+
 
   ###
 
@@ -177,7 +186,7 @@ module.exports = (Norma) ->
     .024 s added
 
   ###
-  require("./utilities/bind-modes")(Norma)
+  require("./utilities/bind-modes")()
 
   ###
 

--- a/lib/utilities/add-env-vars.coffee
+++ b/lib/utilities/add-env-vars.coffee
@@ -1,0 +1,28 @@
+Path = require "path"
+Fs = require "fs"
+_ = require "underscore"
+
+
+module.exports = (cwd) ->
+
+  Norma = require "./../norma"
+
+  cwd or= process.cwd()
+
+  config = Norma.config(cwd)
+  globalConfig = Norma.config Path.resolve(Norma._.userHome)
+
+  if Fs.existsSync Path.join(cwd, ".norma")
+    localSettings = Norma.config Path.join(cwd, ".norma")
+
+  localSettings or= {}
+  globalConfig.env or= {}
+  config.env or= {}
+  localSettings.env or= {}
+
+  env = _.extend globalConfig.env, config.env, localSettings.env
+
+
+  if env
+    for variable, value of env
+      process.env[variable] = value

--- a/lib/utilities/bind-modes.coffee
+++ b/lib/utilities/bind-modes.coffee
@@ -1,10 +1,11 @@
 
-Flags = require("minimist")( process.argv.slice(2) )
-
-Norma = require "./../norma"
 
 
-module.exports = (Norma) ->
+
+module.exports = ->
+  Flags = require("minimist")( process.argv.slice(2) )
+
+  Norma = require "./../norma"
 
   # Mode utilities
   link = (string, key) ->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normajs",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Auto Discover Build Utility",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Environment Variables!
Environment variables can now be registered in norma config files and they will be populated on the process environment. These will be merged in the typical order for Norma (e.g. global < local < settings)

```coffeescript

name: "norma-projects"

tasks:
  javascript:
    src: "_source/pre/**/*"
    dest: "_source/tmp"
  build:
    "@extend": "javascript"
    src: "_source/build.min"
    dest: ""
    order: "post"

env:
  NODE_ENV: "production"
  VELOCITY: 0

```