### PR TITLE
Feature completions

### DIFF
--- a/History.md
+++ b/History.md
@@ -10,7 +10,27 @@
 
 * Overall speed improvements thanks to benchmarking and tweaking
 * The ability to group tasks into task sets similar to how guard can group tasks.
-* Env variables
+
+## 1.6.6
+* simple auto completion for common shells added to Norma.
+
+To enable tasks auto-completion in shell you should add `eval "$(norma --completion=shell)"` in your `.shellrc` file.
+
+#### Bash
+
+Add `eval "$(norma --completion=bash)"` to `~/.bashrc`.
+
+#### Zsh
+
+Add `eval "$(norma --completion=zsh)"` to `~/.zshrc`.
+
+#### Powershell
+
+Add `Invoke-Expression ((norma --completion=powershell) -join [System.Environment]::NewLine)` to `$PROFILE`.
+
+#### Fish
+
+Add `norma --completion=fish | source` to `~/.config/fish/config.fish`.
 
 
 ## 1.6.5

--- a/bin/launcher.coffee
+++ b/bin/launcher.coffee
@@ -5,19 +5,42 @@
 ###
 
 Flags = require("minimist")( process.argv.slice(2) )
-Chalk = require "chalk"
-Path = require "path"
-Fs = require "fs"
-Q = require "kew"
-Flags = require("minimist")( process.argv.slice(2) )
-
-
-Norma = require "../lib/norma"
-AutoUpdate = require "./auto-update"
 
 
 module.exports = (env) ->
+
+
+  Norma = require "../lib/norma"
+  AutoUpdate = require "./auto-update"
+
+
   Norma.args = Flags._
+
+
+  # UTILITY -----------------------------------------------------------------
+
+  # Check for version flag and report version
+  if Flags.version or Flags.v
+
+    versionString = "norma CLI version: #{Chalk.cyan(Norma._.version)}"
+
+    Norma.log versionString
+
+    # exit
+    Norma.close()
+
+  if Flags["tasks-simple"]
+    
+    require("./../lib/logging/completion")()
+
+    Norma.close()
+
+
+
+  Chalk = require "chalk"
+  Path = require "path"
+  Fs = require "fs"
+  Q = require "kew"
 
 
   # we only notify for updates if we are in a long running process (watch)
@@ -34,17 +57,7 @@ module.exports = (env) ->
   )
 
 
-  # UTILITY -----------------------------------------------------------------
 
-  # Check for version flag and report version
-  if Flags.version or Flags.v
-
-    versionString = "norma CLI version: #{Chalk.cyan(Norma._.version)}"
-
-    Norma.log versionString
-
-    # exit
-    Norma.close()
 
 
 

--- a/bin/norma.js
+++ b/bin/norma.js
@@ -5,15 +5,16 @@ var Liftoff = require("liftoff");
 var Flags = require("minimist")(process.argv.slice(2));
 var Domain = require("domain").create();
 
-
 var Norma = require("../lib/index")
 var Launch = require("./launcher")
+var Completion = require("../lib/utilities/completion")
 
 // Set process status
 Norma._.bin = true
 
 var cli = new Liftoff({
-  name: "norma"
+  name: "norma",
+  completions: Completion
 });
 
 // STOP ----------------------------------------------------------------
@@ -38,6 +39,7 @@ Domain.run(function(){
   cli.launch({
     cwd: Flags.cwd,
     verbose: Flags.verbose,
+    completion: Flags.completion,
     extensions: require('interpret').jsVariants
   }, Launch);
 

--- a/lib/logging/README.md
+++ b/lib/logging/README.md
@@ -1,0 +1,20 @@
+# Completion for norma
+> Thanks to the grunt team, specifically Tyler Kellen
+
+To enable tasks auto-completion in shell you should add `eval "$(norma --completion=shell)"` in your `.shellrc` file.
+
+## Bash
+
+Add `eval "$(norma --completion=bash)"` to `~/.bashrc`.
+
+## Zsh
+
+Add `eval "$(norma --completion=zsh)"` to `~/.zshrc`.
+
+## Powershell
+
+Add `Invoke-Expression ((norma --completion=powershell) -join [System.Environment]::NewLine)` to `$PROFILE`.
+
+## Fish
+
+Add `norma --completion=fish | source` to `~/.config/fish/config.fish`.

--- a/lib/logging/bash
+++ b/lib/logging/bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Borrowed from grunt-cli
+# http://gruntjs.com/
+#
+# Copyright (c) 2012 Tyler Kellen, contributors
+# Licensed under the MIT license.
+# https://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+
+# Usage:
+#
+# To enable bash <tab> completion for norma, add the following line (minus the
+# leading #, which is the bash comment character) to your ~/.bashrc file:
+#
+# eval "$(norma --completion=bash)"
+
+# Enable bash autocompletion.
+function _norma_completions() {
+  # The currently-being-completed word.
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  #Grab tasks
+  local compls=$(norma --tasks-simple)
+  # Tell complete what stuff to show.
+  COMPREPLY=($(compgen -W "$compls" -- "$cur"))
+}
+
+complete -o default -F _norma_completions norma

--- a/lib/logging/completion.coffee
+++ b/lib/logging/completion.coffee
@@ -1,0 +1,17 @@
+
+Path = require "path"
+
+MapTree = require("./../utilities/directory-tools").mapTree
+
+module.exports = ->
+
+  tasks = MapTree Path.resolve(__dirname, '../methods/')
+
+  taskList = []
+  for task in tasks.children
+    if not task.path
+      continue
+
+    taskList.push task.name.split('.')[0]
+
+  console.log taskList.join("\n").trim()

--- a/lib/logging/fish
+++ b/lib/logging/fish
@@ -1,0 +1,10 @@
+#!/usr/bin/env fish
+
+# Usage:
+#
+# To enable fish <tab> completion for norma, add the following line to
+# your ~/.config/fish/config.fish file:
+#
+# norma --completion=fish | source
+
+complete -c norma -a "(norma --tasks-simple)" -f

--- a/lib/logging/powershell
+++ b/lib/logging/powershell
@@ -1,0 +1,61 @@
+# Copyright (c) 2014 Jason Jarrett
+#
+# Tab completion for the `norma`
+#
+# Usage:
+#
+# To enable powershell <tab> completion for norma you need to be running
+# at least PowerShell v3 or greater and add the below to your $PROFILE
+#
+#     Invoke-Expression ((norma --completion=powershell) -join [System.Environment]::NewLine)
+#
+#
+
+$norma_completion_Process = {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameter)
+
+
+	# Load up an assembly to read the normafile's sha1
+	if(-not $global:normaSHA1Managed) {
+		[Reflection.Assembly]::LoadWithPartialName("System.Security") | out-null
+		$global:normaSHA1Managed = new-Object System.Security.Cryptography.SHA1Managed
+	}
+
+	# setup a global (in-memory) cache
+	if(-not $global:normafileShaCache) {
+		$global:normafileShaCache = @{};
+	}
+
+	$cache = $global:normafileShaCache;
+
+	# Get the normafile's sha1
+	$sha1normaFile = (resolve-path normafile.js -ErrorAction Ignore | %{
+		$file = [System.IO.File]::Open($_.Path, "open", "read")
+		[string]::join('', ($global:normaSHA1Managed.ComputeHash($file) | %{ $_.ToString("x2") }))
+		$file.Dispose()
+	})
+
+	# lookup the sha1 for previously cached task lists.
+	if($cache.ContainsKey($sha1normaFile)){
+		$tasks = $cache[$sha1normaFile];
+	} else {
+		$tasks = (norma --tasks-simple).split("`n");
+		$cache[$sha1normaFile] = $tasks;
+	}
+
+
+    $tasks |
+        where { $_.startswith($commandName) }
+        Sort-Object |
+        foreach { New-Object System.Management.Automation.CompletionResult $_, $_, 'ParameterValue', ('{0}' -f $_) }
+}
+
+if (-not $global:options) {
+    $global:options = @{
+        CustomArgumentCompleters = @{};
+        NativeArgumentCompleters = @{}
+    }
+}
+
+$global:options['NativeArgumentCompleters']['norma'] = $norma_completion_Process
+$function:tabexpansion2 = $function:tabexpansion2 -replace 'End\r\n{','End { if ($null -ne $options) { $options += $global:options} else {$options = $global:options}'

--- a/lib/logging/zsh
+++ b/lib/logging/zsh
@@ -1,0 +1,25 @@
+#!/bin/zsh
+
+# Borrowed from grunt-cli
+# http://gruntjs.com/
+#
+# Copyright (c) 2012 Tyler Kellen, contributors
+# Licensed under the MIT license.
+# https://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+
+# Usage:
+#
+# To enable zsh <tab> completion for norma, add the following line (minus the
+# leading #, which is the zsh comment character) to your ~/.zshrc file:
+#
+# eval "$(norma --completion=zsh)"
+
+# Enable zsh autocompletion.
+function _norma_completion() {
+  # Grab tasks
+  compls=$(norma --tasks-simple)
+  completions=(${=compls})
+  compadd -- $completions
+}
+
+compdef _norma_completion norma

--- a/lib/utilities/completion.coffee
+++ b/lib/utilities/completion.coffee
@@ -1,0 +1,27 @@
+
+###
+
+  Borrowed from Gulp who also uses Liftoff for completions
+  https://github.com/gulpjs/gulp-cli/blob/ddec6f645a6d2691ced7a5176a8092415d93697f/lib/completion.js
+
+###
+
+Fs = require("fs")
+Path = require("path")
+
+module.exports = (name) ->
+
+  if typeof name isnt "string"
+    throw new Error("Missing completion type")
+
+  file = Path.join(__dirname, "../logging/", name)
+
+  try
+    console.log Fs.readFileSync(file, "utf8")
+    process.exit 0
+  catch err
+    console.log(
+      'echo "norma autocompletion rules for \'#{name}\' not found"'
+    )
+    process.exit 5
+  return

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "normajs",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Auto Discover Build Utility",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Auto competions
simple auto completion for common shells added to Norma.

To enable tasks auto-completion in shell you should add `eval "$(norma --completion=shell)"` in your `.shellrc` file.

#### Bash

Add `eval "$(norma --completion=bash)"` to `~/.bashrc`.

#### Zsh

Add `eval "$(norma --completion=zsh)"` to `~/.zshrc`.

#### Powershell

Add `Invoke-Expression ((norma --completion=powershell) -join [System.Environment]::NewLine)` to `$PROFILE`.

#### Fish

Add `norma --completion=fish | source` to `~/.config/fish/config.fish`.